### PR TITLE
Update event cards

### DIFF
--- a/home/templates/home/home_page.html
+++ b/home/templates/home/home_page.html
@@ -39,41 +39,30 @@
     </div>
   </div>
   <div class="flex flex-row md:flex-col">
-    <div class="col-8 me-4">
+    <div class="md-col-8 md-me-4">
       <h2 class="text-left mb-2 py-4" style="font-family:'Styrene B Bold';">
         Upcoming Events
       </h2>
-      <div class="d-flex">
+      <div class="events-wrapper">
         {% if events %}
         {% for event in events %}
-        <div class="d-flex p-4 me-4 rounded bg-white shadow">
-          <div class="d-flex flex-col justify-items-center align-items-center ">
-            <div>
-              <p>
-                {{ event.start|date:"D" }}
-              </p>
-              <h1>
-                {{ event.start|date:"j" }}
-              </h1>
-              <p>
-                {{ event.start|date:"M" }}
-              </p>
-              </div>
-              {% if event.formation %}
-              <div class="mb-3">
-                {{ event.formation }}
-              </div>
-              {% endif %}
-            </div>
-            <div class="d-flex flex-column justify-content-around event-subtitle mb-3 ps-3 text-end">
-              <span>
-                {{ event.title }}
-              </span>
-              <a href="{{ event.url }}" class="btn btn-primary align-self-center shadow">
-                RSVP
-              </a>
-            </div>
+        <div class="event-card">
+          <div class="event-card-content">
+            <p class="event-card-date">
+              <span>{{ event.start|date:"l, F" }}</span>
+              <span class="red-text">{{ event.start|date:"j" }}<sup>{{ event.start|date:"S" }}</sup></span>
+            </p>
+            <p class="event-card-title">{{ event.title }}</p>
+            {% if event.formation %}
+            <p class="event-card-formation">
+              {{ event.formation }}
+            </p>
+            {% endif %}
           </div>
+          <a href="{{ event.url }}" class="event-card-link" aria-label="Respond to this event">
+            RSVP
+          </a>
+        </div>
         {% endfor %}
         {% else %}
         <p>No upcoming events.</p>

--- a/package-lock.json
+++ b/package-lock.json
@@ -172,7 +172,7 @@
         "yauzl": "^2.10.0"
       },
       "devDependencies": {
-        "cypress": "^12.14.0"
+        "cypress": "^12.17.2"
       }
     },
     "node_modules/@colors/colors": {
@@ -614,13 +614,13 @@
       }
     },
     "node_modules/cypress": {
-      "version": "12.14.0",
-      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.14.0.tgz",
-      "integrity": "sha512-HiLIXKXZaIT1RT7sw1sVPt+qKtis3uYNm6KwC4qoYjabwLKaqZlyS/P+uVvvlBNcHIwL/BC6nQZajpbUd7hOgQ==",
+      "version": "12.17.2",
+      "resolved": "https://registry.npmjs.org/cypress/-/cypress-12.17.2.tgz",
+      "integrity": "sha512-hxWAaWbqQBzzMuadSGSuQg5PDvIGOovm6xm0hIfpCVcORsCAj/gF2p0EvfnJ4f+jK2PCiDgP6D2eeE9/FK4Mjg==",
       "dev": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@cypress/request": "^2.88.10",
+        "@cypress/request": "^2.88.11",
         "@cypress/xvfb": "^1.2.4",
         "@types/node": "^14.14.31",
         "@types/sinonjs__fake-timers": "8.1.1",
@@ -657,7 +657,7 @@
         "pretty-bytes": "^5.6.0",
         "proxy-from-env": "1.0.0",
         "request-progress": "^3.0.0",
-        "semver": "^7.3.2",
+        "semver": "^7.5.3",
         "supports-color": "^8.1.1",
         "tmp": "~0.2.1",
         "untildify": "^4.0.0",
@@ -1496,8 +1496,9 @@
       "license": "MIT"
     },
     "node_modules/semver": {
-      "version": "7.5.1",
-      "license": "ISC",
+      "version": "7.5.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.5.4.tgz",
+      "integrity": "sha512-1bCSESV6Pv+i21Hvpxp3Dx+pSD8lIPt8uVjRrxAUt/nbswYc+tK6Y2btiULjd4+fnq15PX+nqQDC7Oft7WkwcA==",
       "dependencies": {
         "lru-cache": "^6.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -170,7 +170,7 @@
     "yauzl": "^2.10.0"
   },
   "devDependencies": {
-    "cypress": "^12.14.0"
+    "cypress": "^12.17.2"
   },
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,7 +5,7 @@ description = "A Django + Wagtail based website for the St Louis Chapter of DSA"
 authors = ["Tyler Schlichenmeyer <tyler.schlichenmeyer@gmail.com>"]
 
 [tool.poetry.dependencies]
-python = "3.11.3"
+python = "~3.11.3"
 Django = "^4.1.7"
 django-allauth = "^0.51.0"
 django-crispy-forms = "^1.14.0"

--- a/stl_dsa/static/css/project.css
+++ b/stl_dsa/static/css/project.css
@@ -11,32 +11,119 @@ License URI: https://www.gnu.org/licenses/gpl.html
 Tags: fluid-layout responsive-layout
 Text Domain: dsa-v2
 */
-@tailwind base;
-@tailwind components;
-@tailwind utilities;
-
 @import url("https://fonts.googleapis.com/css?family=Open+Sans+Condensed:300,700|Open+Sans:300,400,600");
-@font-face {
-  font-family: "Manifold DSA";
-  src: url(../fonts/manifolddsa/Webfont/ManifoldDSA-Regular.woff);
+@media screen and (min-width: 768px) {
+  .events-wrapper {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+  }
+}
+
+.event-card {
+  display: flex;
+  flex-direction: column;
+  gap: .5rem;
+  background-color: #fff;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1), 0 2px 4px -2px rgba(0, 0, 0, 0.1);
+  transition: box-shadow 120ms linear;
+}
+
+.event-card:hover {
+  box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1), 0 4px 6px -4px rgba(0, 0, 0, 0.1);
+}
+
+@media screen and (min-width: 768px) {
+  .event-card {
+    width: 316px;
+  }
+}
+
+@media screen and (min-width: 992px) {
+  .event-card {
+    width: 285px;
+  }
+}
+
+.event-card + .event-card {
+  margin-top: 1rem;
+}
+
+@media screen and (min-width: 768px) {
+  .event-card + .event-card {
+    margin-top: 0;
+  }
+}
+
+.event-card .event-card-content {
+  display: flex;
+  flex-direction: column;
+  gap: .5rem;
+  flex: 1;
+  padding: .5rem 1rem;
+}
+
+.event-card .event-card-content p {
+  margin: 0;
+}
+
+.event-card .event-card-title {
+  font-size: 1.25em;
+  font-weight: 500;
+}
+
+.event-card .event-card-link {
+  padding-inline: 1rem;
+  padding-block: .5rem;
+  font-size: 1.25em;
+  font-weight: 700;
+  background-color: #ec1f27;
+  color: #fff;
+  transition: color, background-color 120ms linear;
+}
+
+.event-card .event-card-link:hover {
+  background-color: #9f0005;
+}
+
+.event-card .event-card-link:active {
+  background-color: #7f0004;
 }
 
 @font-face {
   font-family: "Manifold DSA";
   src: url(../fonts/manifolddsa/Webfont/ManifoldDSA-Light.woff);
-  font-weight: 100;
+  font-weight: 300;
 }
 
 @font-face {
   font-family: "Manifold DSA";
-  src: url(../fonts/manifolddsa/Webfont/ManifoldDSA-Bold.woff);
+  src: url(../fonts/manifolddsa/Webfont/ManifoldDSA-Regular.woff);
+  font-weight: 400;
+}
+
+@font-face {
+  font-family: "Manifold DSA";
+  src: url(../fonts/manifolddsa/Webfont/ManifoldDSA-Medium.woff);
+  font-weight: 500;
+}
+
+@font-face {
+  font-family: "Manifold DSA";
+  src: url(../fonts/manifolddsa/Webfont/ManifoldDSA-DemiBold.woff);
   font-weight: 600;
 }
 
 @font-face {
   font-family: "Manifold DSA";
-  src: url(../fonts/manifolddsa/Webfont/ManifoldDSA-ExtraBold.woff);
+  src: url(../fonts/manifolddsa/Webfont/ManifoldDSA-Bold.woff);
   font-weight: 700;
+}
+
+@font-face {
+  font-family: "Manifold DSA";
+  src: url(../fonts/manifolddsa/Webfont/ManifoldDSA-ExtraBold.woff);
+  font-weight: 800;
 }
 
 @font-face {
@@ -2245,11 +2332,6 @@ header button {
 
 .dropdown:active > .dropdown-menu {
   display: block;
-}
-
-.navbar-nav {
-  display: flex;
-  flex-direction: row;
 }
 
 .navbar-nav .dropdown-toggle::after {

--- a/stl_dsa/static/sass/_variables.scss
+++ b/stl_dsa/static/sass/_variables.scss
@@ -1,0 +1,65 @@
+// VARIABLES
+// Media Queries
+$small-mobile-query: "screen and ( max-width: 400px )";
+$mobile-query: "screen and ( max-width: 1024px )";
+$desktop-query: "screen and ( min-width: 1024px )";
+
+// Colors
+$white: #fff;
+$white-dark-1x: #fafafa;
+$white-dark-2x: #efefef;
+$white-dark-3x: #ddd;
+$gray: #a0a0a0;
+$black: #000;
+$black-light-1x: #323232;
+$black-light-2x: #6d6d6d;
+$dsared: #ec1f27;
+$darkdsared: #9f0005;
+$darkdsared-1x: #7f0004;
+$dsalightred: #ffe2d6;
+$dsablack: #241f20;
+$dsadarkgrey: #747380;
+$dsamidgrey: #e4e4e8;
+$dsalitegrey: #f6f6f6;
+$dsaredtrans-1x: rgba($dsared, 0.5);
+$dsaredtrans-2x: rgba($dsared, 0.1);
+$blacktrans-1x: rgba($black, 0.5);
+$blacktrans-2x: rgba($black, 0.25);
+$whitetrans-1x: rgba($white, 0.5);
+$whitetrans-2x: rgba($white, 0.25);
+$lightred: desaturate($dsared, 20%);
+$debug: #f06;
+
+// dsa colors from the national design guide
+// https://design.dsausa.org/national-identity/color-palette/
+$ntl-red: #EC1F27;
+$ntl-red-tint-1: #F04C53;
+$ntl-red-tint-2: #F4797E;
+$ntl-red-tint-3: #F7A5A9;
+$ntl-red-tint-4: #FBD2D4;
+$ntl-black: #231F20;
+$ntl-black-tint-1: #3B3838;
+$ntl-black-tint-2: #605C5C;
+$ntl-black-tint-3: #8C8989;
+$ntl-black-tint-4: #C1C0BF;
+
+// Sizes
+$space-xxs: 0.4em;
+$space-xs: 0.6em;
+$space-s: 0.8em;
+$space-l: 1.1em;
+$space-xl: 1.25em;
+$space-2xl: 1.5em;
+$space-3xl: 2em;
+$space-4xl: 2.5em;
+$space-5xl: 3em;
+
+$text-xxs :$space-xxs;
+$text-xs :$space-xs;
+$text-s :$space-s;
+$text-l :$space-l;
+$text-xl :$space-xl;
+$text-2xl :$space-2xl;
+$text-3xl :$space-3xl;
+$text-4xl :$space-4xl;
+$text-5xl :$space-5xl;

--- a/stl_dsa/static/sass/modules/events-card.scss
+++ b/stl_dsa/static/sass/modules/events-card.scss
@@ -1,0 +1,85 @@
+@import "../variables";
+
+.events-wrapper {
+    @media screen and (min-width: 768px) {
+        & {
+            display: flex;
+            flex-wrap: wrap;
+            gap: 1rem;
+        }
+    }
+}
+
+.event-card {
+    display: flex;
+    flex-direction: column;
+    gap: .5rem;
+    background-color: $white;
+    box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1),
+        0 2px 4px -2px rgba(0, 0, 0, 0.1);
+    transition: box-shadow 120ms linear;
+
+    &:hover {
+        box-shadow: 0 10px 15px -3px rgba(0, 0, 0, 0.1),
+            0 4px 6px -4px rgba(0, 0, 0, 0.1);
+        
+
+    }
+
+    @media screen and (min-width: 768px) {
+        & {
+            width: 316px;
+        }
+    }
+
+    @media screen and (min-width: 992px) {
+        & {
+            width: 285px;
+        }
+    }
+
+    & + & {
+        margin-top: 1rem;
+        @media screen and (min-width: 768px) {
+            margin-top: 0;
+        }
+    }
+
+    .event-card-content {
+        display: flex;
+        flex-direction: column;
+        gap: .5rem;
+        flex: 1;
+        padding: .5rem 1rem;
+        
+        p {
+            margin: 0;
+        }
+    }
+
+    // .event-card-date {}
+
+    .event-card-title {
+        font-size: $text-xl;
+        font-weight: 500;
+    }
+
+    .event-card-link {
+        padding-inline: 1rem;
+        padding-block: .5rem;
+        font-size: $text-xl;
+        font-weight: 700;
+        background-color: $dsared;
+        color: $white;
+        transition: color, background-color 120ms linear;
+
+        &:hover {
+            background-color: $darkdsared;
+        }
+
+        &:active {
+            background-color: $darkdsared-1x;
+        }
+    }
+}
+

--- a/stl_dsa/static/sass/project.scss
+++ b/stl_dsa/static/sass/project.scss
@@ -13,69 +13,44 @@ Tags: fluid-layout responsive-layout
 Text Domain: dsa-v2
 */
 
-// VARIABLES
-// Media Queries
-$small-mobile-query: "screen and ( max-width: 400px )";
-$mobile-query: "screen and ( max-width: 1024px )";
-$desktop-query: "screen and ( min-width: 1024px )";
-
-// Colors
-$white: #fff;
-$white-dark-1x: #fafafa;
-$white-dark-2x: #efefef;
-$white-dark-3x: #ddd;
-$gray: #a0a0a0;
-$black: #000;
-$black-light-1x: #323232;
-$black-light-2x: #6d6d6d;
-$dsared: #ec1f27;
-$darkdsared: #9f0005;
-$dsalightred: #ffe2d6;
-$dsablack: #241f20;
-$dsadarkgrey: #747380;
-$dsamidgrey: #e4e4e8;
-$dsalitegrey: #f6f6f6;
-$dsaredtrans-1x: rgba($dsared, 0.5);
-$dsaredtrans-2x: rgba($dsared, 0.1);
-$blacktrans-1x: rgba($black, 0.5);
-$blacktrans-2x: rgba($black, 0.25);
-$whitetrans-1x: rgba($white, 0.5);
-$whitetrans-2x: rgba($white, 0.25);
-$lightred: desaturate($dsared, 20%);
-
-// Sizes
-
-$text-xxs: 0.4em;
-$text-xs: 0.6em;
-$text-s: 0.8em;
-$text-l: 1.1em;
-$text-xl: 1.25em;
-$text-2xl: 1.5em;
-$text-3xl: 2em;
-$text-4xl: 2.5em;
-$text-5xl: 3em;
+// Variables
+@import 'variables';
 
 // Custom Fonts
 @import url("https://fonts.googleapis.com/css?family=Open+Sans+Condensed:300,700|Open+Sans:300,400,600");
 
-@font-face {
-  font-family: "Manifold DSA";
-  src: url(../fonts/manifolddsa/Webfont/ManifoldDSA-Regular.woff);
-}
+// Custom UI Elements
+@import 'modules/events-card';
+
 @font-face {
   font-family: "Manifold DSA";
   src: url(../fonts/manifolddsa/Webfont/ManifoldDSA-Light.woff);
-  font-weight: 100;
+  font-weight: 300;
 }
 @font-face {
   font-family: "Manifold DSA";
-  src: url(../fonts/manifolddsa/Webfont/ManifoldDSA-Bold.woff);
+  src: url(../fonts/manifolddsa/Webfont/ManifoldDSA-Regular.woff);
+  font-weight: 400;
+}
+@font-face {
+  font-family: "Manifold DSA";
+  src: url(../fonts/manifolddsa/Webfont/ManifoldDSA-Medium.woff);
+  font-weight: 500;
+}
+@font-face {
+  font-family: "Manifold DSA";
+  src: url(../fonts/manifolddsa/Webfont/ManifoldDSA-DemiBold.woff);
   font-weight: 600;
 }
 @font-face {
   font-family: "Manifold DSA";
-  src: url(../fonts/manifolddsa/Webfont/ManifoldDSA-ExtraBold.woff);
+  src: url(../fonts/manifolddsa/Webfont/ManifoldDSA-Bold.woff);
   font-weight: 700;
+}
+@font-face {
+  font-family: "Manifold DSA";
+  src: url(../fonts/manifolddsa/Webfont/ManifoldDSA-ExtraBold.woff);
+  font-weight: 800;
 }
 @font-face {
   font-family: "Manifold DSA";


### PR DESCRIPTION
Update the event cards on the home page to be responsive, change type hierarchy.

**before change:**

*mobile*
<img width="911" alt="image" src="https://github.com/stldsa/site/assets/2998575/eec8f17c-2d2f-4804-a348-629ac1b9df91">


*desktop*

<img width="1552" alt="image" src="https://github.com/stldsa/site/assets/2998575/c17b1480-d764-4f68-91cb-98d7b6f5abe8">


**after change:**

*mobile*

<img width="903" alt="image" src="https://github.com/stldsa/site/assets/2998575/18ce6457-789d-4b46-94ef-4d87a2bf0583">


*desktop*

<img width="1552" alt="image" src="https://github.com/stldsa/site/assets/2998575/7f656683-8e30-41b2-8fa9-2633600ef921">


there were a couple unrelated changes as well:
- **`package`/`package-lock`:** these appear to be automated with an install / setup process
- **`pyproject.toml`:** this change was required because I was getting errors where the default setup installed python 3.11.4 instead of 3.11.3
